### PR TITLE
fix deleteProperty method

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,11 @@ function objectChangeCallsite (target, callback) {
       var err = new Error()
       var trace = strip(err.stack)
       callback(prop, undefined, trace)
-      return target.removeItem(prop)
+      if (prop in target) {
+        delete target[prop]
+        return true
+      }
+      return false
     }
   })
 }


### PR DESCRIPTION
hey! cool stuff! 
don't know what's `removeItem` though, shouldn't it look more like this? (which is actually [this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/deleteProperty))