### PR TITLE
Check the error stack length before slicing

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function objectChangeCallsite (target, callback) {
 
 function strip (str) {
   var arr = str.split('\n')
-  arr = arr.slice(2)
+  arr = arr.length > 2 ? arr.slice(2) : arr
   arr[0] = arr[0].replace(/^ {4}at /, '')
   return '\n' + arr.join('\n')
 }


### PR DESCRIPTION
In Safari (iOS and desktop), the erorr stack never seems to be longer than
two frames, so when `arr.slice(2)` occurs, the result is an empty array, so
`arr[0]` is `undefined` rather than a string.

This checks the length of the array and only slices if there are at least 2
elements, otherwise, pass the array through wholesale.