### PR TITLE
Add warning and return target if Proxy not supported

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,11 @@ function objectChangeCallsite (target, callback) {
   assert.equal(typeof target, 'object', 'object-change-callsite: target should be type object')
   assert.equal(typeof callback, 'function', 'object-change-callsite: callback should be type function')
 
+  if (!Proxy) {
+    console.warn('This browser does not support Proxy, and onChange will not work as expected')
+    return target
+  }
+
   return new Proxy(target, {
     set: function (obj, prop, value) {
       var err = new Error()


### PR DESCRIPTION
This checks if Proxy exists, and if it does not exist, it issues a `console.warn()` message and returns `target` instead of a Proxy.

This should fix issue #4 